### PR TITLE
Add SVG badge endpoints for bounties

### DIFF
--- a/src/backend/Sponsorkit.Api/Domain/Controllers/Api/Badges/BadgeSvgFactory.cs
+++ b/src/backend/Sponsorkit.Api/Domain/Controllers/Api/Badges/BadgeSvgFactory.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Globalization;
+using System.Net;
+
+namespace Sponsorkit.Api.Domain.Controllers.Api.Badges;
+
+public static class BadgeSvgFactory
+{
+    public static string Render(string label, string message, string color = "#2ea44f")
+{
+          var labelWidth = Measure(label);
+        var messageWidth = Measure(message);
+        var totalWidth = labelWidth + messageWidth;
+        var messageStart = labelWidth;
+        var labelTextPosition = labelWidth / 2;
+        var messageTextPosition = labelWidth + (messageWidth / 2);
+
+        return
+                      "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"" + totalWidth.ToString(CultureInfo.InvariantCulture) + "\" height=\"20\" role=\"img\" aria-label=\"" + Encode(label + ": " + message) + "\">" +
+                      "<linearGradient id=\"s\" x2=\"0\" y2=\"100%\"><stop offset=\"0\" stop-color=\"#bbb\" stop-opacity=\".1\"/><stop offset=\"1\" stop-opacity=\".1\"/></linearGradient>" +
+                      "<clipPath id=\"r\"><rect width=\"" + totalWidth.ToString(CultureInfo.InvariantCulture) + "\" height=\"20\" rx=\"3\" fill=\"#fff\"/></clipPath>" +
+                      "<g clip-path=\"url(#r)\">" +
+                      "<rect width=\"" + labelWidth.ToString(CultureInfo.InvariantCulture) + "\" height=\"20\" fill=\"#555\"/>" +
+                      "<rect x=\"" + messageStart.ToString(CultureInfo.InvariantCulture) + "\" width=\"" + messageWidth.ToString(CultureInfo.InvariantCulture) + "\" height=\"20\" fill=\"" + Encode(color) + "\"/>" +
+                      "<rect width=\"" + totalWidth.ToString(CultureInfo.InvariantCulture) + "\" height=\"20\" fill=\"url(#s)\"/>" +
+                      "</g>" +
+                      "<g fill=\"#fff\" text-anchor=\"middle\" font-family=\"Verdana,Geneva,DejaVu Sans,sans-serif\" font-size=\"11\">" +
+                      "<text x=\"" + labelTextPosition.ToString(CultureInfo.InvariantCulture) + "\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">" + Encode(label) + "</text>" +
+                      "<text x=\"" + labelTextPosition.ToString(CultureInfo.InvariantCulture) + "\" y=\"14\">" + Encode(label) + "</text>" +
+                      "<text x=\"" + messageTextPosition.ToString(CultureInfo.InvariantCulture) + "\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">" + Encode(message) + "</text>" +
+                      "<text x=\"" + messageTextPosition.ToString(CultureInfo.InvariantCulture) + "\" y=\"14\">" + Encode(message) + "</text>" +
+                      "</g>" +
+                      "</svg>";
+}
+
+    public static string FormatDollarAmount(long amountInHundreds)
+{
+          var amount = amountInHundreds / 100M;
+        return amount % 1 == 0
+                      ? "$" + amount.ToString("0", CultureInfo.InvariantCulture)
+                      : "$" + amount.ToString("0.##", CultureInfo.InvariantCulture);
+}
+
+    private static int Measure(string value)
+{
+          return Math.Max(36, (value.Length * 7) + 10);
+}
+
+    private static string Encode(string value)
+{
+          return WebUtility.HtmlEncode(value);
+}
+}

--- a/src/backend/Sponsorkit.Api/Domain/Controllers/Api/Badges/Repositories/Get.cs
+++ b/src/backend/Sponsorkit.Api/Domain/Controllers/Api/Badges/Repositories/Get.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Ardalis.ApiEndpoints;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Sponsorkit.Api.Domain.Controllers.Api.Badges;
+using Sponsorkit.BusinessLogic.Domain.Models.Database.Context;
+
+namespace Sponsorkit.Api.Domain.Controllers.Api.Badges.Repositories;
+
+public record Request(
+    [FromRoute] string RepositoryOwner,
+    [FromRoute] string RepositoryName);
+
+public class Get : EndpointBaseAsync
+    .WithRequest<Request>
+    .WithActionResult<FileContentResult>
+{
+    private const string SvgContentType = "image/svg+xml; charset=utf-8";
+    private readonly DataContext dataContext;
+
+    public Get(DataContext dataContext)
+    {
+        this.dataContext = dataContext;
+    }
+
+    [HttpGet("badges/repositories/{repositoryOwner}/{repositoryName}/badge.svg")]
+    [AllowAnonymous]
+    [Produces(SvgContentType)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ResponseCache(Duration = 300, Location = ResponseCacheLocation.Any)]
+    public override async Task<ActionResult<FileContentResult>> HandleAsync(
+        [FromRoute] Request request,
+        CancellationToken cancellationToken = new())
+    {
+        var bountyAmounts = await dataContext.Bounties
+            .Where(x =>
+                x.AwardedToId == null &&
+                x.Issue.Repository.GitHub.OwnerName == request.RepositoryOwner &&
+                x.Issue.Repository.GitHub.Name == request.RepositoryName)
+            .Select(x => x.Payments.Sum(p => p.AmountInHundreds))
+            .ToArrayAsync(cancellationToken);
+
+        var amount = bountyAmounts.Sum();
+        var message = bountyAmounts.Length == 1
+            ? $"{BadgeSvgFactory.FormatDollarAmount(amount)} open"
+            : $"{BadgeSvgFactory.FormatDollarAmount(amount)} across {bountyAmounts.Length} open";
+
+        Response.Headers.CacheControl = "public, max-age=300, s-maxage=3600";
+
+        return File(
+            Encoding.UTF8.GetBytes(BadgeSvgFactory.Render("bounties", message)),
+            SvgContentType);
+    }
+}

--- a/src/backend/Sponsorkit.Api/Domain/Controllers/Api/Badges/Users/Get.cs
+++ b/src/backend/Sponsorkit.Api/Domain/Controllers/Api/Badges/Users/Get.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Ardalis.ApiEndpoints;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Sponsorkit.Api.Domain.Controllers.Api.Badges;
+using Sponsorkit.BusinessLogic.Domain.Models.Database.Context;
+
+namespace Sponsorkit.Api.Domain.Controllers.Api.Badges.Users;
+
+public record Request(
+    [FromRoute] string GitHubUsername);
+
+public class Get : EndpointBaseAsync
+    .WithRequest<Request>
+    .WithActionResult<FileContentResult>
+{
+    private const string SvgContentType = "image/svg+xml; charset=utf-8";
+    private readonly DataContext dataContext;
+
+    public Get(DataContext dataContext)
+    {
+        this.dataContext = dataContext;
+    }
+
+    [HttpGet("badges/users/{gitHubUsername}/badge.svg")]
+    [AllowAnonymous]
+    [Produces(SvgContentType)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ResponseCache(Duration = 300, Location = ResponseCacheLocation.Any)]
+    public override async Task<ActionResult<FileContentResult>> HandleAsync(
+        [FromRoute] Request request,
+        CancellationToken cancellationToken = new())
+    {
+        var bountyAmounts = await dataContext.Bounties
+            .Where(x =>
+                x.AwardedTo != null &&
+                x.AwardedTo.GitHub != null &&
+                x.AwardedTo.GitHub.Username == request.GitHubUsername)
+            .Select(x => x.Payments.Sum(p => p.AmountInHundreds))
+            .ToArrayAsync(cancellationToken);
+
+        var amount = bountyAmounts.Sum();
+        var message = bountyAmounts.Length == 1
+            ? $"{BadgeSvgFactory.FormatDollarAmount(amount)} earned"
+            : $"{BadgeSvgFactory.FormatDollarAmount(amount)} across {bountyAmounts.Length} wins";
+
+        Response.Headers.CacheControl = "public, max-age=300, s-maxage=3600";
+
+        return File(
+            Encoding.UTF8.GetBytes(BadgeSvgFactory.Render("bountyhunt", message, "#0366d6")),
+            SvgContentType);
+    }
+}

--- a/src/backend/Sponsorkit.Tests/Api/Domain/Controllers/Badges/BadgeSvgFactoryTest.cs
+++ b/src/backend/Sponsorkit.Tests/Api/Domain/Controllers/Badges/BadgeSvgFactoryTest.cs
@@ -1,0 +1,25 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Sponsorkit.Api.Domain.Controllers.Api.Badges;
+
+namespace Sponsorkit.Tests.Api.Domain.Controllers.Badges;
+
+[TestClass]
+public class BadgeSvgFactoryTest
+{
+    [TestMethod]
+    public void Render_EncodesLabelAndMessage()
+    {
+        var svg = BadgeSvgFactory.Render("a<b", "x&y");
+
+        StringAssert.Contains(svg, "a&lt;b");
+        StringAssert.Contains(svg, "x&amp;y");
+        StringAssert.Contains(svg, "role=\"img\"");
+    }
+
+    [TestMethod]
+    public void FormatDollarAmount_FormatsWholeAndFractionalAmounts()
+    {
+        Assert.AreEqual("$10", BadgeSvgFactory.FormatDollarAmount(10_00));
+        Assert.AreEqual("$10.5", BadgeSvgFactory.FormatDollarAmount(10_50));
+    }
+}


### PR DESCRIPTION
Fixes #70

Summary:
- Add public SVG badge endpoint for repository bounty totals at `/badges/repositories/{repositoryOwner}/{repositoryName}/badge.svg`.
- Add public SVG badge endpoint for bountyhunter/user earnings at `/badges/users/{gitHubUsername}/badge.svg`.
- Render escaped, cacheable shields-style SVG badges and include focused renderer tests.

Verification:
- `dotnet build src/backend/Sponsorkit.Api/Sponsorkit.Api.csproj -p:NuGetAudit=false -p:TreatWarningsAsErrors=false`
- `dotnet test src/backend/Sponsorkit.Tests/Sponsorkit.Tests.csproj --filter BadgeSvgFactoryTest -p:NuGetAudit=false -p:TreatWarningsAsErrors=false`

Note: the unmodified repo currently treats existing restore/analyzer warnings as errors with the local .NET SDK, so I used those flags only for local verification without changing project settings.